### PR TITLE
Github Dark Theme

### DIFF
--- a/src/themes.js
+++ b/src/themes.js
@@ -84,4 +84,11 @@ export const themes = {
     logo: "#eaeaea",
     icon: "#eaeaea",
   },
+  githubdark: {
+    background: "#0E1116",
+    foreground: "#eaeaea",
+    border: "#0E1116",
+    logo: "#eaeaea",
+    icon: "#eaeaea",
+  }
 };


### PR DESCRIPTION
Github Dark Theme is an extension of the tomorrownightbright with the background that blends with Github's native dark theme.